### PR TITLE
Fix command line text color issue for better_logs.py

### DIFF
--- a/openpython/pkgs/better_logs.py
+++ b/openpython/pkgs/better_logs.py
@@ -10,32 +10,40 @@ class log:
     def err(msg: str, errCode: int, color = Fore.RED):
         time = datetime.datetime.now()
         print("{color}[-> {timestamp} <-] (ERR - {code})  >>>  {msg}".format(code=errCode, msg=msg, color=color, timestamp=time))
+        print(Fore.RESET)
 
     def info(msg: str, color = Fore.CYAN):
         time = datetime.datetime.now()
         print("{color}[-> {timestamp} <-] (INFO)  >>>  {msg}".format(msg=msg, color=color, timestamp=time))
+        print(Fore.RESET)
 
     def success(msg: str, color = Fore.GREEN):
         time = datetime.datetime.now()
         print("{color}[-> {timestamp} <-] (SUCCESS)  >>>  {msg}".format(msg=msg, color=color, timestamp=time))
+        print(Fore.RESET)
 
     def crit(msg: str, errCode: int, color = Fore.MAGENTA):
         time = datetime.datetime.now()
         print("{color}[-> {timestamp} <-] (CRIT ERR - {code})  >>>  {msg}".format(code=errCode, msg=msg, color=color, timestamp=time))
+        print(Fore.RESET)
 
     def sys_msg(msg: str, color = Fore.LIGHTBLUE_EX):
         time = datetime.datetime.now()
         print("{color}[-> {timestamp} <-] (SYSTEM MSG)  >>>  {msg}".format(msg=msg, color=color, timestamp=time))
+        print(Fore.RESET)
 
     def shutdown(msg: str, errCode: int, color = Fore.MAGENTA):
         time = datetime.datetime.now()
         print("{color}[-> {timestamp} <-] (SYSTEM ERR - {code})  >>>  {msg}\n--> WARNING: Process exiting due to a system error.".format(code=errCode, msg=msg, color=color, timestamp=time))
+        print(Fore.RESET)
         return exit(404)
 
     def warn(msg: str, color = Fore.YELLOW):
         time = datetime.datetime.now()
         print("{color}[-> {timestamp} <-] (WARNING)  >>>  {msg}".format(msg=msg, color=color, timestamp=time))
+        print(Fore.RESET)
 
     def log(msg: str, color = Fore.WHITE):
         time = datetime.datetime.now()
         print("{color}[-> {timestamp} <-] (LOG) >>>  {msg}".format(msg=msg, color=color, timestamp=time))
+        print(Fore.RESET)


### PR DESCRIPTION
## Issue Description
The command line text color doesn't reset back to its default color in windows 10 command prompt/powershell.
![Screenshot 2024-09-28 172838](https://github.com/user-attachments/assets/26175c79-7529-462f-a1a5-ea22c426d6db)

### Solution
Added `print(Fore.RESET)` after each print statement. This ensures that the color of the command line stays its default white color.